### PR TITLE
Update README with current skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,23 @@ A collection of [Agent Skills](https://agentskills.io) for building Streamlit ap
 
 Agent Skills are specialized instruction sets that enhance AI coding assistants' capabilities for specific tasks. Each skill contains instructions, scripts, and resources that the AI loads dynamically to improve performance on Streamlit development workflows.
 
-## Available Skills
+## Available skills
 
 | Skill | Description |
 |-------|-------------|
-| [streamlit-app-basics](skills/streamlit-app-basics/) | Build Streamlit applications following best practices |
+| [building-streamlit-chat-ui](skills/building-streamlit-chat-ui/) | Chat interfaces, chatbots, AI assistants |
+| [building-streamlit-dashboards](skills/building-streamlit-dashboards/) | KPI cards, metrics, dashboard layouts |
+| [building-streamlit-multipage-apps](skills/building-streamlit-multipage-apps/) | Multi-page app structure and navigation |
+| [choosing-streamlit-selection-widgets](skills/choosing-streamlit-selection-widgets/) | Choosing the right selection widget |
+| [connecting-streamlit-to-snowflake](skills/connecting-streamlit-to-snowflake/) | Connecting to Snowflake with st.connection |
+| [customizing-streamlit-theme](skills/customizing-streamlit-theme/) | Custom colors via config.toml |
+| [displaying-streamlit-data](skills/displaying-streamlit-data/) | Dataframes, column config, charts |
+| [improving-streamlit-design](skills/improving-streamlit-design/) | Icons, badges, spacing, text styling |
+| [optimizing-streamlit-performance](skills/optimizing-streamlit-performance/) | Caching, fragments, forms, static vs dynamic widgets |
+| [organizing-streamlit-code](skills/organizing-streamlit-code/) | Separating UI from business logic, modules |
+| [setting-up-streamlit-environment](skills/setting-up-streamlit-environment/) | Python environment setup |
+| [using-streamlit-custom-components](skills/using-streamlit-custom-components/) | Third-party components from the community |
+| [using-streamlit-layouts](skills/using-streamlit-layouts/) | Sidebar, columns, containers, dialogs |
 
 ## Installation
 
@@ -19,7 +31,7 @@ Agent Skills are specialized instruction sets that enhance AI coding assistants'
 Copy a skill folder to your Claude Code skills directory:
 
 ```bash
-cp -r skills/streamlit-app-basics ~/.claude/skills/
+cp -r skills/optimizing-streamlit-performance ~/.claude/skills/
 ```
 
 Or reference skills directly in your project by adding them to your `.claude/skills/` directory.
@@ -29,7 +41,7 @@ Or reference skills directly in your project by adding them to your `.claude/ski
 Copy a skill folder to your [Cursor skills directory](https://cursor.com/docs/context/skills):
 
 ```bash
-cp -r skills/streamlit-app-basics ~/.cursor/skills/
+cp -r skills/optimizing-streamlit-performance ~/.cursor/skills/
 ```
 
 Or add skills directly to your project's `.cursor/skills/` directory.


### PR DESCRIPTION
## Summary

Update the README to list all 13 current skills instead of the old `streamlit-app-basics` placeholder.

## Changes

- Replace single `streamlit-app-basics` entry with all 13 skills
- Update installation examples to use `optimizing-streamlit-performance` as the example skill
- Fix sentence casing on "Available skills" heading

## Test plan

- [x] Verify all skill links are correct