### PR TITLE
Add skill for deploying to Community Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ Agent Skills are specialized instruction sets that enhance AI coding assistants'
 
 ## Available skills
 
-The main skill is [`developing-with-streamlit`](developing-with-streamlit/SKILL.md), which routes to specialized sub-skills:
+There are two skills:
+
+- [`developing-with-streamlit`](developing-with-streamlit/SKILL.md) for building apps, which routes to specialized sub-skills
+- [`deploying-streamlit-community-cloud`](deploying-streamlit-community-cloud/SKILL.md) for deploying apps to Streamlit Community Cloud
+
+### Developing with Streamlit sub-skills
 
 | Skill | Description |
-|-------|-------------|
+| ------- | ------------- |
 | [building-streamlit-chat-ui](developing-with-streamlit/skills/building-streamlit-chat-ui/) | Chat interfaces, chatbots, AI assistants |
 | [building-streamlit-dashboards](developing-with-streamlit/skills/building-streamlit-dashboards/) | KPI cards, metrics, dashboard layouts |
 | [building-streamlit-multipage-apps](developing-with-streamlit/skills/building-streamlit-multipage-apps/) | Multi-page app structure and navigation |
@@ -54,7 +59,7 @@ Or add skills directly to your project's `.cursor/skills/` directory.
 ### Other AI Assistants
 
 | Agent | Skills Folder | Documentation |
-|-------|---------------|---------------|
+| ------- | --------------- | --------------- |
 | OpenAI Codex | `.codex/skills/` | [Codex Skills Docs](https://developers.openai.com/codex/skills/) |
 | Gemini CLI | `.gemini/skills/` | [Gemini CLI Skills Docs](https://geminicli.com/docs/cli/skills/) |
 | GitHub Copilot | `.github/skills/` | [Copilot Agent Skills Docs](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) |

--- a/deploying-streamlit-community-cloud/SKILL.md
+++ b/deploying-streamlit-community-cloud/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: deploying-streamlit-community-cloud
+description: Deploys Streamlit apps to Streamlit Community Cloud using the Streamlit CLI. Use when publishing an app or turning a local project into a GitHub repo for deployment.
+---
+
+# Deploying to Streamlit Community Cloud
+
+Use this skill to deploy a Streamlit app to Streamlit Community Cloud via the
+`streamlit cloud deploy` CLI command (Streamlit 1.54+).
+
+## When to activate
+
+- Publishing a Streamlit app to Community Cloud
+- Converting a local project into a GitHub repo for deployment
+- Triggering a deploy from the CLI
+
+## Requirements
+
+- **Streamlit 1.54+** (for `streamlit cloud deploy`)
+- A GitHub repo with your app code
+- A Community Cloud account connected to GitHub
+- `gh` CLI installed and authenticated if a repo needs to be created
+
+## Deployment flow
+
+### 1) Verify Streamlit version
+
+```bash
+streamlit version
+```
+
+If `streamlit cloud deploy` is missing or Streamlit is <1.54, **tell the user
+explicitly that they need Streamlit 1.54 for this skill to work** and ask them
+to upgrade before continuing.
+
+### 2) Check whether the current directory is a GitHub repo
+
+```bash
+git rev-parse --is-inside-work-tree
+git remote -v
+```
+
+If the repo has a GitHub remote (URL contains `github.com`), run:
+
+```bash
+streamlit cloud deploy
+```
+
+### 3) If not a GitHub repo, offer to create one
+
+If the current directory is not a git repo, or it has no GitHub remote, offer
+to initialize and push it to the user's GitHub account. Then:
+
+```bash
+git init
+git add -A
+git commit -m "Initial commit"
+gh auth status
+gh repo create <repo-name> --source=. --remote=origin --push
+```
+
+Notes:
+
+- If `gh auth status` fails, run `gh auth login` first.
+- Use `--public` or `--private` depending on the user's preference.
+- If there are already commits, skip the initial commit step.
+
+Once the GitHub repo is created and pushed, run:
+
+```bash
+streamlit cloud deploy
+```
+
+## What the command does
+
+`streamlit cloud deploy` opens the Streamlit Community Cloud deploy page with
+the repository, branch, and app file pre-filled for the current GitHub repo.
+
+## References
+
+- [Deploy your app on Community Cloud](https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/deploy)


### PR DESCRIPTION
Adds a skill to deploy apps to Community Cloud. This requires the new `streamlit cloud deploy` command we're planning to add in 1.54 (https://github.com/streamlit/streamlit/pull/13651), so should only be merged after 1.54 is released. 