### PR TITLE
Deprecate: meta-skill now ships with Streamlit (canonical source of truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Agent Skills for Streamlit Development
 
+> [!WARNING]
+> **This repository is deprecated and is being archived.**
+>
+> The `developing-with-streamlit` **meta-skill now lives in and ships with Streamlit itself** — [**`streamlit/streamlit`**](https://github.com/streamlit/streamlit) is the canonical source of truth. As of Streamlit **1.60+** the meta-skill is bundled in the pip package at [`lib/streamlit/.agents/meta-skill/developing-with-streamlit`](https://github.com/streamlit/streamlit/tree/develop/lib/streamlit/.agents/meta-skill/developing-with-streamlit), and `streamlit skills` installs it from your local install — no download from this repo.
+>
+> - **Recommended:** `pip install --upgrade streamlit` (1.60+), then `streamlit skills`.
+> - **Existing installs keep working.** This repo stays public and its `v1` tag is preserved, so `npx skills` / `gh skill` / `git clone` installs continue to resolve; `discover.py` runs entirely locally, so archiving does not affect it.
+> - **New development and fixes to the meta-skill happen in [`streamlit/streamlit`](https://github.com/streamlit/streamlit), not here.**
+
 A lightweight **meta-skill** that teaches AI coding assistants (Claude Code, Cursor, and others) how to discover and load the Streamlit development skills bundled inside the Streamlit pip package (1.57+).
 
 ## What are Agent Skills?
@@ -77,7 +86,7 @@ If you prefer project-scoped install, copy to `.claude/skills/` in your repo roo
 gh skill install streamlit/agent-skills developing-with-streamlit --scope user
 ```
 
-Available via the GitHub CLI (`gh`) as of April 2026. Drop `--scope user` to install to the current repo only, or pin a version with `developing-with-streamlit@v1.0.0`. See the [Copilot agent skills docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/add-skills).
+Available via the GitHub CLI (`gh`) as of April 2026. Drop `--scope user` to install to the current repo only, or pin a version with `developing-with-streamlit@v1`. See the [Copilot agent skills docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/add-skills).
 
 ### Cursor
 


### PR DESCRIPTION
> [!CAUTION]
> ## 🛑 DO NOT MERGE until Streamlit 1.60 has shipped
>
> This PR tells users the meta-skill now lives in [`streamlit/streamlit`](https://github.com/streamlit/streamlit) — but that only becomes true once [streamlit/streamlit#16026](https://github.com/streamlit/streamlit/pull/16026) is merged **and released in 1.60 on PyPI**. Merging this (or archiving the repo) any earlier would point users at a "source of truth" that isn't in a released wheel yet, while older Streamlit versions still depend on this repo's download path.
>
> **Required order:** land #16026 → **ship 1.60** → merge this README PR → archive `streamlit/agent-skills` (keep the `v1` tag; never delete/privatize).

---

## Deprecate this repo — the meta-skill now ships with Streamlit

The `developing-with-streamlit` **meta-skill is now the canonical property of [`streamlit/streamlit`](https://github.com/streamlit/streamlit)**: it is vendored in and shipped with the Streamlit pip package (1.60+) at [`lib/streamlit/.agents/meta-skill/developing-with-streamlit`](https://github.com/streamlit/streamlit/tree/develop/lib/streamlit/.agents/meta-skill/developing-with-streamlit), and `streamlit skills --global` installs it **from the local package** instead of downloading from this repo.

That change (streamlit/streamlit#16026) removes the runtime GitHub download that caused ~12% install failures on locked-down Windows networks and resolves a security-review concern about runtime external downloads. With the meta-skill living in the wheel, this repo is no longer the source of truth.

### This PR
- Adds a **deprecation banner** to the README pointing to `streamlit/streamlit` as the canonical source of truth for the meta-skill.
- Fixes a stale version-pin example (`developing-with-streamlit@v1.0.0` → `@v1`; only the `v1` tag exists).

### What happens to existing installs
- **Nothing breaks.** This repo will be **archived, not deleted** — it stays public and its `v1` tag is preserved, so existing `npx skills` / `gh skill` / `git clone` installs keep resolving. `discover.py` is 100% local, so an archived repo has no runtime effect on it.
- Going forward, meta-skill development and fixes happen in `streamlit/streamlit`.

### Merge/rollout order
1. Land streamlit/streamlit#16026 (vendors the meta-skill) and ship it in **1.60**.
2. Merge this README PR.
3. Archive `streamlit/agent-skills` (keep the `v1` tag; never delete or make private).

Part of streamlit/streamlit#16026 · fixes streamlit/streamlit#15933 rollout.
